### PR TITLE
Bug. Byte-wise comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+lib/
+venv/

--- a/lib/TunnaClient.py
+++ b/lib/TunnaClient.py
@@ -336,7 +336,7 @@ class TunnaClient():
             # send options
             resp = self.HTTPreq(url)
 
-            if (resp[:4] == '[OK]'):  # If ok is received (non-php webshell): Thread not needed
+            if (resp[:4] == b'[OK]'):  # If ok is received (non-php webshell): Thread not needed
                 print('[-] Keep-alive thread not required')
             # if ok/proxy is not received something went wrong (if nothing is received: it's a PHP webshell)
             else:


### PR DESCRIPTION
Added .gitignore.

Fixed a comparison error `"[OK]" != b"[OK]"`.